### PR TITLE
Added straight run prioritisation

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,17 @@
+contourpy==1.3.3
+cycler==0.12.1
+drawsvg==2.4.0
+fonttools==4.59.0
+kiwisolver==1.4.9
+matplotlib==3.10.5
+networkx==3.5
+numpy==2.3.2
+packaging==25.0
+pillow==11.3.0
+pyparsing==3.2.3
+python-dateutil==2.9.0.post0
+PyYAML==6.0.2
+shapely==2.1.1
+six==1.17.0
+svgelements==1.9.6
+utm==0.8.1

--- a/src/sld.py
+++ b/src/sld.py
@@ -1930,6 +1930,7 @@ def draw_connections(
             all_connection_nodes=all_connection_nodes,
             busbar_weight=BUSBAR_WEIGHT,
             busbar_crossing_penalty=100000,
+            iterations=PATHFINDING_ITERATIONS
         )
 
         # Build a map of nodes to the orientation of paths passing through them.


### PR DESCRIPTION
Configured the path straightening algorithm to prefer 'L' swaps that lengthen the straight runs in the path. Tends to result in longer straight runs in paths rather than having unnecessary wiggling or zig-zagging in the paths.

# Before
<img width="2858" height="1556" alt="image" src="https://github.com/user-attachments/assets/5149d791-18e5-4293-a1fa-199e79be9587" />

# After
<img width="2874" height="1586" alt="after" src="https://github.com/user-attachments/assets/14e9a38d-429a-4866-bd0d-8a3505517a65" />

