### PR TITLE
Several QLD components added to substation_definitions.yaml

### DIFF
--- a/src/substation_definitions.yaml
+++ b/src/substation_definitions.yaml
@@ -3948,3 +3948,726 @@ substations:
         rel_x: 1
         rel_y: 4
         connections: {}
+  - name: Gladstone South T19
+    lat: -23.8848381
+    long: 151.27394741
+    voltage_kv: 132
+    tags:
+      - Gladstone South Ergon
+      - T19
+    def: |
+      1d
+      2d
+    buses:
+      1: ""
+    connections:
+      1: QLD-132-T152-T19-7268
+      2: QLD-132-T152-T19-7269
+    objects:
+      - type: tx-ud
+        metadata:
+          w1: 132
+          w2: 66
+        rel_x: 1
+        rel_y: 2
+        connections:
+          1: QLD-132-T19-7268
+          2: QLD-66-T19-7268
+      - type: tx-ud
+        metadata:
+          w1: 132
+          w2: 66
+        rel_x: 3
+        rel_y: 2
+        connections:
+          1: QLD-132-T19-7269
+          2: QLD-66-T19-7269
+    child_definitions:
+      - def: |
+          x|
+          x| 
+        voltage_kv: 66
+        rel_x: 0
+        rel_y: 8      
+  - name: Rolleston T163
+    lat: -24.38929693483699 
+    long: 148.436085705633
+    voltage_kv: 132
+    tags:
+      - Rolleston
+      - T163
+    def: |
+      |x
+      1||x
+    buses: 
+      1: ""
+    connections:
+      1: QLD-132-T263-T163-7450
+  - name: Memooloo T263
+    lat: -24.13428906098856 
+    long: 148.67856408130953
+    voltage_kv: 132
+    tags:
+      - Memooloo
+      - T263
+    def: |
+      2x|x4
+      i
+      i
+      3x|x1
+    buses:
+      1: "1"
+    connections:
+      1: QLD-132-T32-T263-7286
+      2: QLD-132-T263-1
+      3: QLD-132-T263-2
+      4: QLD-132-T263-T163-7450
+  - name: Bluff T209
+    lat: -23.58812899037114 
+    long: 149.03992254302875
+    voltage_kv: 132
+    tags:
+      - Bluff
+      - T209
+    def: |
+      x|
+      x|1
+      x|
+    buses:
+      1: ""
+    connections:
+      1: QLD-132-T32-T209-7367
+    objects:
+      - type: gen
+        metadata:
+          voltage: 66
+          text: SVC
+          info: |
+            Bluff SVC
+            MVAr/ MVAr
+        rel_x: 5
+        rel_y: -4
+  - name: Duringa T210
+    lat:  -23.71068983255724 
+    long: 149.67911678154636
+    voltage_kv: 132
+    tags:
+      - Duringa
+      - T210
+    def: |
+      x|
+      x|x1
+      x|
+    buses:
+      1: ""
+    connections:
+      1: QLD-132-T32-T210-7114/3
+    objects:
+      - type: gen
+        metadata:
+          voltage: 66
+          text: SVC
+          info: |
+            Duringa SVC
+            MVAr/ MVAr
+        rel_x: 5
+        rel_y: -4
+  - name: Duringa Switching Station # Network T with circuit breakers. Shown as switching station
+    lat: -23.846877958620322 
+    long: 149.46772392838304
+    voltage_kv: 132
+    tags:
+      - Duringa Switching Station
+    def: |
+      |x2
+      |x3
+      |x1
+    connections: 
+      1: QLD-132-T32-T210-7114/1
+      2: QLD-132-T32-T210-7114/2
+      3: QLD-132-T32-T210-7114/3
+  - name: Gregory T97
+    lat: -23.13803070443053  
+    long: 148.42537685471498
+    voltage_kv: 132
+    tags:
+      - Gregory
+      - T97
+    def: |
+      x|
+      x|1
+      x|
+    buses:
+      1: ""
+    connections:
+      1: QLD-132-TH15-T97-7171
+    objects:
+      - type: gen
+        metadata:
+          voltage: 66
+          text: SVC
+          info: |
+            Gregory SVC
+            MVAr/ MVAr
+        rel_x: 5
+        rel_y: -4
+  - name: Broadsound H20
+    lat:  -22.82092152081286 
+    long: 149.40439153734812
+    voltage_kv: 275
+    tags:
+      - Broadsound
+      - H20
+    def: |
+      |/x1x||
+      |x2x3x||
+      |x4x5x||
+      |x6x7x||
+      |x8xd|||
+    buses: 
+      1: "1"
+      2: "2"
+    connections:
+      1:  QLD-275-H20-H11-8846
+      2:  QLD-275-H20-H29-8831
+      3:  QLD-275-H20-H11-8847
+      4:  QLD-275-H20-H10-820
+      5:  QLD-275-H20-H11-834
+      6:  QLD-275-H20-H29-856
+      7:  QLD-275-H20-H15-833
+      8:  QLD-275-H20-H15-850 
+  - name: Bouldercombe H10
+    lat:  -23.537272551133324 
+    long: 150.4869463622723
+    voltage_kv: 275
+    tags:
+      - Bouldercombe
+      - H10
+    def: |
+      |x1x2x||
+      |x3x4x||
+      |xx5x||
+      |xx7x||
+      |x8xd|||
+    buses: 
+      1: "1"
+      2: "2"
+    connections:
+      1:  QLD-275-H10-1
+      2:  QLD-275-H10-821
+      3:  QLD-275-H10-H73-811
+      4:  QLD-275-H20-H10-820
+      5:  QLD-275-H10-H29-849
+      6:  QLD-275-H10-812
+      7:  QLD-275-H10-H29-848
+      8:  QLD-275-H10-2
+  - name: Lilyvale H15
+    lat: -23.128761887324693 
+    long: 148.42910889185265
+    voltage_kv: 275
+    tags:
+      - Lilyvale
+      - H15
+    def: |
+      |x1x2x||3
+      |/4xd|||
+    buses:
+      1: ""
+      2: ""
+    connections:
+      1: QLD-275-H20-H15-850 
+      2: QLD-275-H15-1
+      3: QLD-275-H20-H15-833
+      4: QLD-275-H15-2
+
+  - name: Raglan H73
+    lat: -23.75117034247749 
+    long: 150.83781563251014
+    voltage_kv: 275
+    tags:
+      - Raglan
+      - H73
+    def: |
+      |/x1x||
+      |x2xd|||
+      |x3x4x||
+    buses:
+      1: "2"
+      2: "1"
+    connections:
+      1: QLD-275-H10-H73-811
+      2: QLD-275-H73-1
+      3: QLD-275-H73-2
+      4: QLD-275-H73-H58-8875
+    objects:
+      - type: tx-ud
+        metadata:
+          w1: 132 #todo confirm voltage
+          w2: 275 
+        rel_x: 4
+        rel_y: -6
+        connections:
+          2: QLD-275-H73-1
+      - type: tx-ud
+        metadata:
+          w1: 132 #todo confirm voltage
+          w2: 275 
+        rel_x: 6
+        rel_y: -6
+        connections:
+          2: QLD-275-H73-2 
+  - name: Larcom Creek H58
+    lat: -23.823196397682675 
+    long: 151.06979040685565
+    voltage_kv: 275
+    tags:
+      - Larcom Creek
+      - H58
+    def: |
+      |x1xd|||
+      |x2xd|||
+      |x3x4x||
+    buses:
+      1: "2"
+      2: "1"
+    connections:
+      1: QLD-275-H73-H58-8875 
+      2: QLD-275-H58-T199-7353
+      3: QLD-275-H58-T199-7352
+      4: QLD-275-H58-H67-8859
+    objects:
+      - type: tx-ud
+        metadata:
+          w1: 132
+          w2: 275
+        rel_x: 4
+        rel_y: -6
+        connections:
+          2: QLD-275-H58-T199-7353
+          1: QLD-132-H58-T199-7353
+      - type: tx-ud
+        metadata:
+          w1: 132
+          w2: 275
+        rel_x: 6
+        rel_y: -6
+        connections:
+          2: QLD-275-H58-T199-7352
+          1: QLD-132-H58-T199-7352
+  - name: Stanwell H29
+    lat: -23.515733925787522 
+    long: 150.31999808403344
+    voltage_kv: 275
+    tags:
+      - Stanwell
+      - H29
+    def: |
+      |x1x2x||
+      |x3x4d||
+      |x5x6x||
+      |x7x89x||
+      |x10x11x||
+      |x12x13x||
+      |x14xd|||
+    buses:
+      1: "2"
+      2: "1"
+    connections:
+      1: QLD-275-H10-H29-849
+      2: QLD-275-H29-1-Gen_1
+      3: QLD-275-H10-H29-848
+      4: QLD-275-H29-1-Gen_2
+      5: QLD-275-H29-H24-8873
+      6: QLD-275-H29-2-Gen_1
+      7: QLD-275-H29-H24-8874
+      8: QLD-275-H29-2-Gen_2
+      9: QLD-275-H29-8831-1
+      10: QLD-275-H29-H24-855
+      11: QLD-275-H29-Gen_3
+      12: QLD-275-H29-856
+      13: QLD-275-H29-Gen_4
+      14: QLD-275-H29-8831-2
+    objects:
+      - type: tx-ud
+        metadata:
+          w1: 275
+          w2: 22
+        rel_x: 8
+        rel_y: 12
+        connections:
+          1: QLD-275-H29-Gen_3
+      - type: gen
+        metadata:
+          voltage: 22
+          text: G
+          info: |
+            Stanwell Unit 3
+            385MW
+        rel_x: 8 
+        rel_y: 17
+  - name: Yarwun T199
+    lat: -23.831314840584916 
+    long: 151.15291595687685
+    voltage_kv: 132
+    def: |
+      |x1x2x||
+      |x3x4x||
+      |x5x6x||
+      |x7x8x||
+    buses:
+      1: "2"
+      2: "1"
+    connections:
+      1: QLD-132-T199-YARWUM_1
+      2: QLD-132-T199-T130-7290
+      3: QLD-132-T199-Yarwun-3
+      4: QLD-132-T199-T130-7291
+      5: QLD-132-T199-Yarwun-1
+      6: QLD-132-H58-T199-7353
+      7: QLD-132-T199-Yarwun-2
+      8: QLD-132-H58-T199-7352  
+    objects:
+      - type: tx-ud
+        metadata:
+          w1: 132
+          w2: 132 #todo confirm voltage
+        rel_x: 4
+        rel_y: -6
+        connections:
+          2: QLD-132-T199-Yarwun-3 
+      - type: tx-ud
+        metadata:
+          w1: 132
+          w2: 132 #todo confirm voltage
+        rel_x: 6
+        rel_y: -6
+        connections:
+          2: QLD-132-T199-Yarwun-1 
+      - type: tx-ud
+        metadata:
+          w1: 132
+          w2: 132 #todo confirm voltage
+        rel_x: 8
+        rel_y: -6
+        connections:
+          2: QLD-132-T199-Yarwun-2                     
+  - name: Kamerunga (T53)
+    lat: -16.86610674024463 
+    long: 145.6873405166515
+    voltage_kv: 132
+    tags:
+      - T53
+    def: |
+      |1
+      2x|
+      |x3
+      i
+      |x4
+      5x|
+      |6
+    connections:
+      1: QLD-132-T53-H39-7141
+      2: QLD-132-T53-T54-7184
+      3: QLD-132-T53-TX1
+      4: QLD-132-T53-TX2
+      5: QLD-132-T53-T54-7143
+      6: QLD-132-T53-H39-7142
+    objects:
+      - type: tx-ud
+        metadata:
+          w1: 132
+          w2: 22
+        rel_x: 5 
+        rel_y: 3
+        connections:
+            1: QLD-132-T53-TX1
+            2: QLD-22-T53-ERGON_1
+      - type: tx-ud
+        metadata:
+          w1: 132
+          w2: 22
+        rel_x: 9
+        rel_y: 3
+        connections:
+            1: QLD-132-T53-TX2
+            2: QLD-22-T53-ERGON_2
+  - name: Barron Gorge PS
+    lat: -16.850578581118945 
+    long: 145.64671179191433
+    voltage_kv: 132
+    tags:
+      - Barron Gorge
+    def: |
+      1
+      2
+    connections:
+      1: QLD-132-T53-T54-7184
+      2: QLD-132-T53-T54-7143
+    objects:
+      - type: tx-ud
+        metadata: 
+          w1: 22
+          w2: 132
+        rel_x: 1
+        rel_y: -4
+      - type: tx-ud
+        metadata: 
+          w1: 22
+          w2: 132
+        rel_x: 3
+        rel_y: -4
+  - name: Nebo H11
+    lat: -21.631786358834013 
+    long: 148.68330096370002
+    voltage_kv: 275
+    tags:
+      - Nebo
+      - H11
+    def: |
+      |x1x2x||
+      3x|ddd|||x4
+      |x5x6x||
+      |x7x8x||
+      |x9x10x||
+      |x11x12x||
+      |x13x14x||
+    buses:
+      1: "1"
+      2: "2"
+    connections:
+      1: QLD-275-H20-H11-8846
+      2: QLD-275-H11-132-1
+      3: QLD-275-H11-CAP1
+      4: QLD-275-H11-CAP2
+      5: QLD-275-H10-821
+      6: QLD-275-H11-132-2
+      7: QLD-275-H20-H11-8847
+      8: QLD-275-H11-132-3
+      9: QLD-275-H20-H11-834
+      10: QLD-275-H11-H35-822
+      11: QLD-275-H11-SVC1
+      12: QLD-275-H11-H35-8845
+      13: QLD-275-H11-REA1
+      14: QLD-275-H11-H35-878
+  - name: Calliope River H67
+    lat: -23.85602884165558 
+    long: 151.19219317467957
+    voltage_kv: 275
+    def: |
+      |x1x2x|
+      |x3x4x||
+      |dx5x||
+      |dx6x||
+      |x7xd|||
+      |x8x9x||
+      |x10x11x||
+    buses:
+      1: "1"
+      2: "2"
+    connections:
+      1: QLD-275-H67-TX1
+      2: QLD-275-H67-GSTONE6-8879
+      3: QLD-275-H67-TX2
+      4: QLD-275-H67-GSTONE5-8878
+      5: QLD-275-H67-GSTONE2-8877
+      6: QLD-275-H67-GSTONE1-8876
+      7: QLD-275-H67-H40-818
+      8: QLD-275-H67-H6-814
+      9: QLD-275-H58-H67-8859
+      10: QLD-275-H67-H6-813
+      11: QLD-275-H10-812
+  - name: Calvale H24
+    lat: -24.342451015948317
+    long: 150.6270361556359
+    voltage_kv: 275
+    tags:
+      - Calvale
+      - H24
+    def: |
+      |dx1x||
+      |dx2x||
+      |x3x4x||
+      |x5x6x||
+      |x7x8x||
+      |x9x10x||
+      |x11x12x||
+    buses:
+      1: "2"
+      2: "1"
+    connections:
+      1: QLD-275-H29-H24-855
+      2: QLD-275-H29-H24-8873
+      3: QLD-275-H24-TX1
+      4: QLD-275-H29-H24-8874
+      5: QLD-275-H24-TX2
+      6: QLD-275-H24-CALL_B_1-851
+      7: QLD-275-H24-H40-871
+      8: QLD-275-H24-CALL_B_2-852
+      9: QLD-275-H24-S2-8810
+      10: QLD-275-H24-CPP_3-853
+      11: QLD-275-H24-S2-8810
+      12: QLD-275-H24-CCP_4-854
+  - name: Wurdong H40
+    lat: -23.96064489672159 
+    long: 151.28888805120297
+    voltage_kv: 275
+    tags:
+      - Wurdong
+      - H40
+    def: |
+      |x1x2x||
+      |x3x4x||
+      5x|ddd|||x6
+      |x7x8x||
+    buses:
+      1: "2"
+      2: "1"
+    connections:
+      1: QLD-275-H40-H8-865
+      2: QLD-275-H67-H40-818
+      3: QLD-275-H40-H8-866
+      4: QLD-275-H24-H40-871
+      5: QLD-275-H40-CAP1
+      6: QLD-275-H40-CAP2
+      7: QLD-275-H40-CAP3
+      8: QLD-275-H40-H6-819  
+  - name: Gin Gin H6
+    lat: -24.90142830060005 
+    long: 151.81946272035472
+    voltage_kv: 275
+    tags:
+      - Gin Gin
+      - H6
+    def: |
+      1x|ddd||x2
+      |x3x4x||
+      |x5x6x||
+      |x7x8x||
+      |EEE||x9
+    buses:
+      1: "2"
+      2: "1"
+    connections:
+      1: QLD-275-H6-TX1
+      2: QLD-275-H6-TX2B
+      3: QLD-275-H6-H63-826
+      4: QLD-275-H40-H6-819 
+      5: QLD-275-H6-H5-816
+      6: QLD-275-H67-H6-814
+      7: QLD-275-H6-H5-815
+      8: QLD-275-H67-H6-813
+      9: QLD-275-H6-CAP1
+  - name: Teebar Creek H63
+    lat: -25.690465631075188 
+    long: 152.2472045723108
+    voltage_kv: 275
+    tags:
+      - Teebar Creek
+      - H63
+    def: |
+      |x1x2x3||
+      |x3xd|||
+      |dx4x||
+    buses:
+      1: "2"
+      2: "1"
+    connections:
+      1: QLD-275-H6-H63-826
+      2: QLD-275-H63-TX1
+      3: QLD-275-H63-TX1
+      4: QLD-275-H63-H5-8850
+  - name: Woolooga H5
+    lat: -26.08955533569063 
+    long: 152.43863603316805
+    voltage_kv: 275
+    tags:
+      - Woolooga
+      - H5
+    def: |
+      |x1x2x||
+      3x|EEE||
+      |dx4x||
+      |x5x6x||
+      |x7x8x9||
+      |dx9x||
+    buses:
+      1: "1"
+      2: "2"
+    connections:
+      1: QLD-275-H5-SVC1
+      2: QLD-275-H5-TX3
+      3: QLD-275-H5-CAP1
+      4: QLD-275-H5-TX5
+      5: QLD-275-H5-H9-810
+      6: QLD-275-H63-H5-8850
+      7: QLD-275-H5-H2-807
+      8: QLD-275-H6-H5-816
+      9: QLD-275-H6-H5-815
+  - name: Palmwoods H9 
+    lat: -26.7071891474412 
+    long: 152.9363313502972
+    voltage_kv: 275
+    tags:
+      - Palmwoods
+      - H9
+    def: |
+      |x1x2x||
+      |EEE||x3
+      |ddx4||
+      5|EEE||
+    buses:
+      1: "2"
+      2: "1"
+    connections:
+      1: QLD-275-H9-TX2
+      2: QLD-275-H5-H9-810
+      3: QLD-275-H9-CAP1
+      4: QLD-275-H9-TX1
+      5: QLD-275-H9-H2-808
+  # - name: Western Downs S5 # note - connection point with three new bays
+  #   lat: -26.930993966236674
+  #   long: 50.73304369727774
+  #   voltage_kv: 275
+  #   tags:
+  #     - Western Downs
+  #     - S5
+  #   def: |
+  #     |x1x2x||
+  #     |x3x4x||
+  #     |x5x6x||
+  #     |x7x8x||
+  #   buses:
+  #     1: "1"
+  #     2: "2"
+  #   connections:
+  #     1: QLD-275-S5-R2-8864
+  #     2: QLD-275-S5-H77-8890
+  #     3: QLD-275-S5-R2-8820
+  #     4: QLD-275-S5-H78-8889
+  #     5: QLD-275-S5-S2-8867
+  #     6: Empty
+  #     7: QLD-275-S5-H60-8904
+  #     8: QLD-25-S5-KPP_1-8865
+  # - name: Coopers Gap H60
+  #   lat: -26.735338140387576 
+  #   long: 151.47453862790132
+  #   voltage_kv: 275
+  #   tags:
+  #     - Coopers Gap
+  #     - H60
+  #   def: |
+  #     |E||1
+  #     |x2x3||
+  #     |d4x||
+  #   buses:
+  #     1: "2"
+  #     2: "1"
+  #   connections:
+  #     1: QLD-275-S5-H60-8904
+  #     2: QLD-275-S5-COOPGWF1-TX2
+  #     3: QLD-275-S5-S2-8866
+  #     4: QLD-275-S5-COOPGWF1-TX1
+
+      
+    
+    


### PR DESCRIPTION
QLD assets added. Largely focusing on 275kV grid in northern and central QLD